### PR TITLE
Escape HTML

### DIFF
--- a/summary_html/cve_summary.html
+++ b/summary_html/cve_summary.html
@@ -140,7 +140,14 @@
                 "aoColumns": [
                     { "sWidth": "5%" },
                     { "sWidth": "10%" },
-                    { "sWidth": "55%" },
+                    {
+                      "sWidth": "55%",
+                      "data": 2,
+                      "render": function(data, type, row) {
+                        // Escape and return the description
+                        return $('<div/>').text(data).html();
+                      }
+                },
                     { "sWidth": "20%" },
                     { "sWidth": "10%" },
                 ],


### PR DESCRIPTION
The description of **CVE-2024-8366** contains `<script>alert(1)</script>` which gets executed when CVE summary is viewed. This PR prevents the payloads in description from being executed by escaping the description.