### PR TITLE
Add CVE-Flow to blacklist

### DIFF
--- a/blacklist.txt
+++ b/blacklist.txt
@@ -24,3 +24,4 @@ RedHatOfficial/rhsecapi
 RedHatProductSecurity/cve-pylib
 oracle-japan/ochacafe-s5-3
 mergebase/usn2json
+404notf0und/CVE-Flow


### PR DESCRIPTION
Add the CVE-Flow repo to the blacklist which doesn't include any PoCs.